### PR TITLE
修復找不到 flashplayer_sa.exe

### DIFF
--- a/撈金魚/MainWindow.xaml.cs
+++ b/撈金魚/MainWindow.xaml.cs
@@ -37,7 +37,7 @@ namespace 撈金魚
     /// </summary>
     public partial class MainWindow : Window
     {
-        GetProgramWindow window = new GetProgramWindow("flashplayer_32_sa");
+        GetProgramWindow window = new GetProgramWindow("flashplayer_*");
         public const int MOLE_W = 960, MOLE_H = 560, BUCKET_NET_X = 150, BUCKET_NET_Y = -10, BUCKET_WATER_X = 235, BUCKET_WATER_Y = 415, NET_FIX_X = 50, NET_FIX_Y = 45;
 
         private void Button_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
由於我用的是 CleanFlash 版本號比摩爾莊園的 Flashplayer 版本還要高，所以檔案是 flashplayer_sa.exe
但是官方給出的檔案是 Flashplayer_32_sa.exe
所以我修復了這個問題，直接指定全部的 flashplayer
不管是 32_sa 還是 sa 都可以讀取

但是因為我這邊 Dependency 有點卡住，不能 Compile 測試。
所以可能要請你幫忙測試一下摟

